### PR TITLE
ENHANCEMENT Don’t automatically show inferred campaigns

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,17 +31,23 @@ matrix:
       env: NPM_TEST=1
 
 before_script:
-  - export CORE_RELEASE=$TRAVIS_BRANCH
+# Init PHP
   - printf "\n" | pecl install imagick
-  - if [[ $PHPCS_TEST ]]; then pyrus install pear/PHP_CodeSniffer; fi
   - phpenv rehash
   - phpenv config-rm xdebug.ini
+  - export PATH=~/.composer/vendor/bin:$PATH
+  - echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
+# Install composer
   - composer validate
   - composer install --prefer-dist
   - composer require --prefer-dist --no-update symfony/config:^3.2 silverstripe/framework:4.0.x-dev embed/embed:^3.0@stable silverstripe/config:1.0.x-dev silverstripe/versioned:1.0.x-dev silverstripe/assets:1.0.x-dev silverstripe/admin:1.0.x-dev
   - composer update
   - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --prefer-dist; fi
   - if [[ $DB == SQLITE ]]; then composer require silverstripe/sqlite3:2.0.x-dev --prefer-dist; fi
+  - if [[ $PHPCS_TEST ]]; then composer global require squizlabs/php_codesniffer:^3 --prefer-dist --no-interaction --no-progress --no-suggest -o; fi
+
+# Install NPM dependencies
   - if [[ $NPM_TEST ]]; then nvm install $TRAVIS_NODE_VERSION && npm install -g yarn && yarn install --network-concurrency 1 && yarn run build; fi
 
 script:

--- a/tests/php/CampaignAdminTest.php
+++ b/tests/php/CampaignAdminTest.php
@@ -2,15 +2,30 @@
 
 namespace SilverStripe\CampaignAdmin\Tests;
 
-use SilverStripe\Dev\SapphireTest;
-use SilverStripe\CampaignAdmin\CampaignAdmin;
 use ReflectionClass;
+use SilverStripe\CampaignAdmin\CampaignAdmin;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\FieldType\DBDatetime;
+use SilverStripe\Versioned\ChangeSet;
 
 class CampaignAdminTest extends SapphireTest
 {
     protected $extraDataObjects = [
         CampaignAdminTest\InvalidChangeSet::class,
     ];
+
+    protected static $fixture_file = 'CampaignAdminTest.yml';
+
+    protected function setUp()
+    {
+        parent::setUp();
+        DBDatetime::set_mock_now('2011-09-24 11:11:00');
+        CampaignAdmin::config()->set('sync_expires', 300);
+        CampaignAdmin::config()->set('show_published', false);
+        CampaignAdmin::config()->set('show_inferred', false);
+        $this->logInWithPermission('ADMIN');
+    }
 
     /**
      * Call a protected method on an object via reflection
@@ -33,7 +48,85 @@ class CampaignAdminTest extends SapphireTest
         $changeset = new CampaignAdminTest\InvalidChangeSet();
         $admin = new CampaignAdmin();
 
-        $result = $this->callProtectedMethod($admin, 'getChangeSetResource', [$changeset]);
+        $result = $this->callProtectedMethod($admin, 'getChangeSetResource', [$changeset, true]);
         $this->assertEquals('Corrupt database! bad data', $result['Details']);
+    }
+
+    /**
+     * Test sync
+     */
+    public function testSync()
+    {
+        $admin = CampaignAdmin::create();
+
+        /** @var ChangeSet $changeset */
+        $changesetID = $this->idFromFixture(ChangeSet::class, 'change1');
+        $admin->readCampaigns();
+
+        // Check initial sync date
+        $lastSynced = ChangeSet::get()->byID($changesetID)->LastSynced;
+        $this->assertEquals('2011-09-24 11:11:00', $lastSynced);
+
+        // After 10 seconds, sync should not be modified when viewing campaigns
+        DBDatetime::set_mock_now('2011-09-24 11:11:10');
+        $admin->readCampaigns();
+        $lastSynced = ChangeSet::get()->byID($changesetID)->LastSynced;
+        $this->assertEquals('2011-09-24 11:11:00', $lastSynced);
+
+        // After 7 minutes sync will trigger a refresh
+        DBDatetime::set_mock_now('2011-09-24 11:18:00');
+        $admin->readCampaigns();
+        $lastSynced = ChangeSet::get()->byID($changesetID)->LastSynced;
+        $this->assertEquals('2011-09-24 11:18:00', $lastSynced);
+    }
+
+    public function testFilters()
+    {
+        $admin = CampaignAdmin::create();
+
+        // Test limited items
+        /** @var DataList $results */
+        $results = $this->callProtectedMethod($admin, 'getListItems');
+        $this->assertDOSEquals(
+            [
+                [ 'Name' => 'changeset 1' ],
+            ],
+            $results
+        );
+
+        // Test published, no inferred
+        CampaignAdmin::config()->set('show_published', true);
+        $results = $this->callProtectedMethod($admin, 'getListItems');
+        $this->assertDOSEquals(
+            [
+                [ 'Name' => 'changeset 1' ],
+                [ 'Name' => 'changeset 2' ],
+            ],
+            $results
+        );
+
+        // Test published + inferred
+        CampaignAdmin::config()->set('show_inferred', true);
+        $results = $this->callProtectedMethod($admin, 'getListItems');
+        $this->assertDOSEquals(
+            [
+                [ 'Name' => 'changeset 1' ],
+                [ 'Name' => 'changeset 2' ],
+                [ 'Name' => 'changeset 3' ],
+                [ 'Name' => 'changeset 4' ],
+            ],
+            $results
+        );
+
+        // Test inferred, no published
+        CampaignAdmin::config()->set('show_published', false);
+        $results = $this->callProtectedMethod($admin, 'getListItems');
+        $this->assertDOSEquals(
+            [
+                [ 'Name' => 'changeset 1' ],
+                [ 'Name' => 'changeset 3' ],
+            ],
+            $results
+        );
     }
 }

--- a/tests/php/CampaignAdminTest.yml
+++ b/tests/php/CampaignAdminTest.yml
@@ -1,0 +1,18 @@
+SilverStripe\Versioned\ChangeSet:
+  change1:
+    Name: 'changeset 1'
+    State: open
+    IsInferred: false
+  change2:
+    Name: 'changeset 2'
+    State: published
+    IsInferred: false
+  change3:
+    Name: 'changeset 3'
+    State: open
+    IsInferred: true
+  change4:
+    Name: 'changeset 4'
+    State: published
+    IsInferred: true
+


### PR DESCRIPTION
API Allow campaign visibility to be configured by type via config
ENHANCEMENT Minimise excessive sync behaviour

Requires https://github.com/silverstripe/silverstripe-versioned/pull/44