### PR TITLE
Expose as vendor module

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,1 +1,0 @@
-Deny from all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
-dist: precise
-
-sudo: false
+dist: trusty
 
 addons:
   apt:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "silverstripe/campaign-admin",
     "description": "SilverStripe campaign admin interface",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "homepage": "http://silverstripe.org",
     "license": "BSD-3-Clause",
     "keywords": [
@@ -23,7 +23,8 @@
     "require": {
         "silverstripe/admin": "^1@dev",
         "silverstripe/framework": "^4@dev",
-        "silverstripe/versioned": "^1@dev"
+        "silverstripe/versioned": "^1@dev",
+        "silverstripe/vendor-plugin": "^1.0"
     },
     "require-dev": {
         "phpunit/PHPUnit": "~4.8"
@@ -32,7 +33,11 @@
         "branch-alias": {
             "1.x-dev": "1.0.x-dev",
             "dev-master": "2.x-dev"
-        }
+        },
+        "expose": [
+            "client/dist",
+            "client/lang"
+        ]
     },
     "autoload": {
         "psr-4": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
-    "@silverstripe/webpack-config": "^0.3.0",
+    "@silverstripe/webpack-config": "^0.4.0",
     "babel-jest": "^19.0.0",
     "jest-cli": "^19.0.2"
   },
@@ -57,10 +57,10 @@
     ],
     "modulePaths": [
       "client/src",
-      "../silverstripe-admin/client/src",
-      "../silverstripe-admin/node_modules",
-      "silverstripe-admin/client/src",
-      "silverstripe-admin/node_modules"
+      "../admin/client/src",
+      "../admin/node_modules",
+      "vendor/silverstripe/admin/client/src",
+      "vendor/silverstripe/admin/node_modules"
     ],
     "testMatch": [
       "**/tests/**/*-test.js?(x)"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 Standard module phpunit configuration.
 Requires PHPUnit ^5.7
 -->
-<phpunit bootstrap="framework/tests/bootstrap.php" colors="true">
+<phpunit bootstrap="vendor/silverstripe/framework/tests/bootstrap.php" colors="true">
 	<testsuite name="Default">
 		<directory>tests/php</directory>
     </testsuite>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@silverstripe/webpack-config@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@silverstripe/webpack-config/-/webpack-config-0.3.0.tgz#5d07c5fe128ecef3cf2b888b5660ed9cfd4c0da1"
+"@silverstripe/webpack-config@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@silverstripe/webpack-config/-/webpack-config-0.4.0.tgz#991041d839be43efb5903ba8de4771321cc67844"
   dependencies:
     autoprefixer "^6.4.0"
     babel-core "^6.24.1"
@@ -4671,8 +4671,8 @@ rc@^1.1.7:
     strip-json-comments "~2.0.1"
 
 react-addons-test-utils@^15.3.1:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz#062d36117fe8d18f3ba5e06eb33383b0b85ea5b9"
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-addons-test-utils/-/react-addons-test-utils-15.6.2.tgz#c12b6efdc2247c10da7b8770d185080a7b047156"
 
 react-bootstrap-ss@^0.30.9:
   version "0.30.10"
@@ -4690,8 +4690,8 @@ react-bootstrap-ss@^0.30.9:
     warning "^3.0.0"
 
 react-dom@^15.3.1:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.1.tgz#2cb0ed4191038e53c209eb3a79a23e2a4cf99470"
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.1.0"
@@ -4739,8 +4739,8 @@ react-router@^2.4.1:
     warning "^3.0.0"
 
 react@^15.3.1:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.1.tgz#baa8434ec6780bde997cdc380b79cd33b96393df"
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
   dependencies:
     create-react-class "^15.6.0"
     fbjs "^0.8.9"


### PR DESCRIPTION
See https://github.com/silverstripe/silverstripe-framework/issues/7405

Merge after https://github.com/silverstripe/silverstripe-framework/pull/7395

Note that I haven't added `silverstripe/vendor-plugin` as a dep, see https://github.com/silverstripe/silverstripe-framework/pull/7395#discussion_r141218532

Test (after merging the framework pull request):

```
composer config repositories.campaign-admin vcs https://github.com/open-sausages/silverstripe-campaign-admin.git
composer require "silverstripe/campaign-admin:dev-pulls/1/vendorise-me-baby as 1.0.x-dev"
```