### PR TITLE
Update recipe branching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_script:
 
 # Install composer
   - composer validate
-  - composer require --prefer-dist --no-update silverstripe/recipe-testing:^1 silverstripe/recipe-cms:1.2.x-dev
+  - composer require --prefer-dist --no-update silverstripe/recipe-testing:^1 silverstripe/recipe-cms:4.2.x-dev
   - if [[ $DB == PGSQL ]]; then composer require --prefer-dist --no-update silverstripe/postgresql:2.0.x-dev; fi
   - if [[ $DB == SQLITE ]]; then composer require --prefer-dist --no-update silverstripe/sqlite3:2.0.x-dev; fi
   - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile


### PR DESCRIPTION
Parent issue: https://github.com/silverstripe/recipe-core/issues/24

From 4.2 onwards all recipes will use the same numbering as the core framework version.