### PR TITLE
Use PHP 7.2 for Behat, prevents HTTP_RAW_POST_DATA errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_script:
 # Install composer
   - composer validate
   - composer require --prefer-dist --no-update silverstripe/recipe-testing:^1 silverstripe/recipe-cms:4.2.x-dev
-  - if [[ $DB == PGSQL ]]; then composer require --prefer-dist --no-update silverstripe/postgresql:2.0.x-dev; fi
+  - if [[ $DB == PGSQL ]]; then composer require --prefer-dist --no-update silverstripe/postgresql:2.1.x-dev; fi
   - if [[ $DB == SQLITE ]]; then composer require --prefer-dist --no-update silverstripe/sqlite3:2.0.x-dev; fi
   - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
   include:
     - php: 5.6
       env: DB=PGSQL PHPUNIT_TEST=1 PHPCS_TEST=1
-    - php: 5.6
+    - php: 7.2
       env: DB=MYSQL BEHAT_TEST=1
     - php: 7.0
       env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1


### PR DESCRIPTION
The Behat failures (currently on PHP 5.6) are not reproducible locally. I've fixed the artifact upload script path in 7e185c644cc90a905544cd5280358114078a77c3 and checked them - we get this in the screenshot:

https://s3.amazonaws.com/silverstripe-travis-artifacts/silverstripe/silverstripe-campaign-admin/405176020/405176022/screenshots/populate-campaigns.feature_33.png

And this in the logs (hard to tell if this is the cause but it probably is, since it's related to GraphQL):

```
[Wed Jul 18 02:44:38 2018] PHP Deprecated:  Automatically populating $HTTP_RAW_POST_DATA is deprecated and will be removed in a future version. To avoid this warning set 'always_populate_raw_post_data' to '-1' in php.ini and use the php://input stream instead. in Unknown on line 0
[Wed Jul 18 02:44:38 2018] PHP Warning:  Cannot modify header information - headers already sent in Unknown on line 0
```

Related: https://github.com/silverstripe/silverstripe-graphql/issues/48

This should hopefully fix the Behat tests in Travis