### PR TITLE
NEW Add to Campaign button in SiteTree now lives in campaign-admin

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,3 +4,7 @@ Name: campaignadmin
 SilverStripe\Admin\LeftAndMain:
   extensions:
     - SilverStripe\CampaignAdmin\CampaignAdminExtension
+
+SilverStripe\CMS\Model\SiteTree:
+  extensions:
+    - SilverStripe\CampaignAdmin\SiteTreeExtension

--- a/src/SiteTreeExtension.php
+++ b/src/SiteTreeExtension.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SilverStripe\CampaignAdmin;
+
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Tab;
+use SilverStripe\ORM\DataExtension;
+use SilverStripe\Security\Permission;
+
+/**
+ * Handles adding the "Add to Campaign" button to a page's secondary actions menu
+ */
+class SiteTreeExtension extends DataExtension
+{
+    public function updateCMSActions(FieldList $actions)
+    {
+        // Add to campaign option if not-archived and has publish permission
+        if ((!$this->owner->isPublished() && !$this->owner->isOnDraft())
+            || !$this->owner->canPublish()
+            || !Permission::check('CMS_ACCESS_CampaignAdmin')
+        ) {
+            return;
+        }
+
+        /** @var Tab $moreOptions */
+        $moreOptions = $actions->fieldByName('ActionMenus.MoreOptions');
+        if (!$moreOptions) {
+            return;
+        }
+
+        $moreOptions->insertAfter(
+            'Information',
+            AddToCampaignHandler_FormAction::create()
+                ->removeExtraClass('btn-primary')
+                ->addExtraClass('btn-secondary')
+        );
+    }
+}

--- a/tests/php/SiteTreeExtensionTest.php
+++ b/tests/php/SiteTreeExtensionTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace SilverStripe\CampaignAdmin\Tests;
+
+use SilverStripe\CampaignAdmin\SiteTreeExtension;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\SapphireTest;
+
+class SiteTreeExtensionTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+
+    protected static $required_extensions = [
+        SiteTree::class => [
+            SiteTreeExtension::class,
+        ],
+    ];
+
+    public function testAddToCampaignButtonIsAdded()
+    {
+        $this->logInWithPermission();
+
+        $page = new SiteTree();
+        $page->write();
+        $actions = $page->getCMSActions();
+
+        $informationField = $actions->fieldByName('ActionMenus.MoreOptions.action_addtocampaign');
+        $this->assertNotNull($informationField, 'Add To Campaign button should have been added');
+    }
+
+    public function testAddToCampaignButtonIsNotAddedWhenUserDoesNotHavePermission()
+    {
+        $this->logInWithPermission('EDIT_PERMISSIONS');
+
+        $page = new SiteTree();
+        $page->write();
+        $page->publishSingle();
+        $actions = $page->getCMSActions();
+
+        $informationField = $actions->fieldByName('ActionMenus.MoreOptions.action_addtocampaign');
+        $this->assertNull($informationField, 'Add To Campaign button should not have been added when published');
+    }
+}


### PR DESCRIPTION
Requires matching CMS PR: https://github.com/silverstripe/silverstripe-cms/pull/2382

Issue: https://github.com/silverstripe/silverstripe-campaign-admin/issues/19