### PR TITLE
FIX Implicit changeset items should be able to opt out of UI display in campaign admin

### DIFF
--- a/src/CampaignAdmin.php
+++ b/src/CampaignAdmin.php
@@ -308,7 +308,9 @@ class CampaignAdmin extends LeftAndMain implements PermissionProvider
 
                 /** @var ChangesetItem $changeSetItem */
                 $resource = $this->getChangeSetItemResource($changeSetItem);
-                $hal['_embedded']['items'][] = $resource;
+                if ($resource) {
+                    $hal['_embedded']['items'][] = $resource;
+                }
             }
 
         // An unexpected data exception means that the database is corrupt
@@ -324,12 +326,18 @@ class CampaignAdmin extends LeftAndMain implements PermissionProvider
      * Build item resource from a changesetitem
      *
      * @param ChangeSetItem $changeSetItem
-     * @return array
+     * @return array|false
      */
     protected function getChangeSetItemResource(ChangeSetItem $changeSetItem)
     {
         $baseClass = DataObject::getSchema()->baseDataClass($changeSetItem->ObjectClass);
         $baseSingleton = DataObject::singleton($baseClass);
+
+        // Allow items to opt out of being displayed in changesets
+        if ($baseSingleton->config()->get('hide_in_campaigns')) {
+            return false;
+        }
+
         $thumbnailWidth = (int)$this->config()->get('thumbnail_width');
         $thumbnailHeight = (int)$this->config()->get('thumbnail_height');
         $hal = [

--- a/src/CampaignAdmin.php
+++ b/src/CampaignAdmin.php
@@ -308,7 +308,7 @@ class CampaignAdmin extends LeftAndMain implements PermissionProvider
 
                 /** @var ChangesetItem $changeSetItem */
                 $resource = $this->getChangeSetItemResource($changeSetItem);
-                if ($resource) {
+                if (!empty($resource)) {
                     $hal['_embedded']['items'][] = $resource;
                 }
             }
@@ -326,7 +326,7 @@ class CampaignAdmin extends LeftAndMain implements PermissionProvider
      * Build item resource from a changesetitem
      *
      * @param ChangeSetItem $changeSetItem
-     * @return array|false
+     * @return array
      */
     protected function getChangeSetItemResource(ChangeSetItem $changeSetItem)
     {
@@ -335,7 +335,7 @@ class CampaignAdmin extends LeftAndMain implements PermissionProvider
 
         // Allow items to opt out of being displayed in changesets
         if ($baseSingleton->config()->get('hide_in_campaigns')) {
-            return false;
+            return [];
         }
 
         $thumbnailWidth = (int)$this->config()->get('thumbnail_width');


### PR DESCRIPTION
Implicitly added changes (via an ORM relationship or similar) are automatically shown in campaign views. There should have been a way for individual models to opt out of this if for example they are link models or something else that should be invisible to CMS users.

This PR adds configuration checks for opt out in order for this to be possible.

Issue: https://github.com/dnadesign/silverstripe-elemental/issues/593