### PR TITLE
ENH Added cascade_add_to_campaign property

### DIFF
--- a/src/AddToCampaignHandler.php
+++ b/src/AddToCampaignHandler.php
@@ -317,6 +317,13 @@ class AddToCampaignHandler
 
         $changeSet->addObject($object);
 
+        $childObjects = $object->findRelatedObjects('cascade_add_to_campaign');
+        if ($childObjects) {
+            foreach ($childObjects as $childObject) {
+                $changeSet->addObject($childObject);
+            }
+        }
+
         $request = $this->controller->getRequest();
         $message = _t(
             __CLASS__ . '.Success',


### PR DESCRIPTION
### Summary
Added `$cascade_addtocampaign` property. This explicitly adds related objects to a ChangeSet when "Add to campaign" is clicked. This allows us to bulk publish child objects without defining them in `$owns` (sometimes we want to publish data on the parent object, without publishing all child objects too).

```
class Category extends DataObject {

  private static $db = [
    "Description" => "HTMLText", // We may want to change and publish just this Content, without effecting Products
  ];

  private static $many_many = [
    'Products' => Product::class,
  ];
  
  // Allows us to bulk publish Products in a Category
  private static $cascade_addtocampaign = [
    "Products",
  ];

}
```

### Testing
- [ ] define a `$cascade_addtocampaign` property on a parent DataObject like the setup above
- [ ] add a parent object with children to a campaign
- [ ] confirm the relationships are added to the same campaign

### Notes
- We require this functionality for a site running on php 7.3, so this is set to merge into the 1.9 branch.