### PR TITLE
API Deprecate extension to be replaced with config

### DIFF
--- a/src/CampaignAdminExtension.php
+++ b/src/CampaignAdminExtension.php
@@ -4,13 +4,23 @@ namespace SilverStripe\CampaignAdmin;
 
 use SilverStripe\Admin\LeftAndMain;
 use SilverStripe\Core\Extension;
+use SilverStripe\Dev\Deprecation;
 use SilverStripe\View\Requirements;
 
 /**
  * @extends Extension<LeftAndMain>
+ * @deprecated 5.3.0 Will be replaced with YAML configuration
  */
 class CampaignAdminExtension extends Extension
 {
+    public function __construct()
+    {
+        Deprecation::withNoReplacement(
+            fn () => Deprecation::notice('5.3.0', 'Will be replaced with YAML configuration', Deprecation::SCOPE_CLASS)
+        );
+        parent::__construct();
+    }
+
     public function init()
     {
         Requirements::add_i18n_javascript('silverstripe/campaign-admin: client/lang', false);


### PR DESCRIPTION
This extension can be entirely replaced with YAML configuration, so we'll do that.

## Issue
- https://github.com/silverstripe/.github/issues/194