### PR TITLE
MNT Fix broken behat tests

### DIFF
--- a/tests/behat/features/manage-campaigns.feature
+++ b/tests/behat/features/manage-campaigns.feature
@@ -5,7 +5,7 @@ Feature: Manage campaigns
   So that I can control bulk publication of content efficiently
 
   Background:
-    Given a "campaign" "Test Campaign" with "Description"="this is a test"
+    Given a "ChangeSet" "Test Campaign" with "Description"="this is a test"
       And the "group" "EDITOR" has permissions "Access to 'Pages' section" and "Access to 'Campaigns' section" and "Access to 'Files' section" and "FILE_EDIT_ALL"
       And the "group" "CAMPAIGNS_EDITOR" has permissions "Access to 'Campaigns' section"
 

--- a/tests/behat/features/populate-campaigns.feature
+++ b/tests/behat/features/populate-campaigns.feature
@@ -7,7 +7,7 @@ Feature: Populate campaigns
   Background:
     Given a "page" "About Us"
     And a "image" "assets/folder1/file2.jpg"
-    And a "Campaign" "Empty Campaign"
+    And a "ChangeSet" "Empty Campaign"
     And a campaign "Full Campaign" with changes "image"="assets/folder1/file2.jpg" and "page"="About Us"
     And the "group" "EDITOR" has permissions "Access to 'Pages' section" and "Access to 'Campaigns' section" and "Access to 'Files' section" and "FILE_EDIT_ALL"
     And I am logged in as a member of "EDITOR" group


### PR DESCRIPTION
Fixes https://github.com/silverstripe/silverstripe-campaign-admin/actions/runs/13779472377/job/38534990949

```text
Given a "campaign" "Test Campaign" with "Description"="this is a test" # SilverStripe\CampaignAdmin\Tests\Behat\Context\FixtureContext::stepCreateRecordWithData()
Class "Campaign" does not exist, or is not a subclass of DataObjet (InvalidArgumentException)
```

It's not clear why it was passing before, but there's definitely no class named `Campaign` - the campaign admin just uses `ChangeSet` and `ChangeSetItem`.

## Issue
- https://github.com/silverstripe/.github/issues/376