### PR TITLE
ENH Reduce queries by using new *byList methods

### DIFF
--- a/src/Extensions/CMSMainExtension.php
+++ b/src/Extensions/CMSMainExtension.php
@@ -11,14 +11,15 @@ class CMSMainExtension extends Extension
 {
     function updateArchiveWarningMessage(string &$message, array $descendants)
     {
-        $inChangeSetIDs = ChangeSetItem::get()->filter([
+        $inChangeSetList = ChangeSetItem::get()->filter([
             'ObjectID' => $descendants,
             'ObjectClass' => SiteTree::class
-        ])->column('ChangeSetID');
+        ]);
         $affectedChangeSetCount = 0;
-        if (count($inChangeSetIDs ?? []) > 0) {
+        if ($inChangeSetList->exists()) {
             $affectedChangeSetCount = ChangeSet::get()
-                ->filter(['ID' => $inChangeSetIDs, 'State' => ChangeSet::STATE_OPEN])
+                ->filter(['State' => ChangeSet::STATE_OPEN])
+                ->filterByList($inChangeSetList, 'ID', 'ChangeSetID')
                 ->count();
         }
         if ($affectedChangeSetCount === 0) {


### PR DESCRIPTION
Some queries can be combined using the new filterByList and excludeByList queries on DataList. This reduces latency overhead and provides an opportunity for the database optimiser to do its thing

> [!IMPORTANT]
> Requires https://github.com/silverstripe/silverstripe-framework/pull/11804


## Issue

- https://github.com/silverstripe/.github/issues/416