### PR TITLE
FIX Generate correct archive message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
         "silverstripe/standards": "^1",
         "phpstan/extension-installer": "^1.3"
     },
+    "conflict": {
+        "silverstripe/cms": "<6.0.2"
+    },
     "extra": {
         "expose": [
             "client/dist",

--- a/src/Extensions/CMSMainExtension.php
+++ b/src/Extensions/CMSMainExtension.php
@@ -6,11 +6,16 @@ use SilverStripe\Core\Extension;
 use SilverStripe\Versioned\ChangeSet;
 use SilverStripe\Versioned\ChangeSetItem;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\ORM\DataObject;
 
 class CMSMainExtension extends Extension
 {
     function updateArchiveWarningMessage(string &$message, array $descendants)
     {
+        /** @var DataObject $record */
+        $record = func_get_arg(2);
+        // Get all changesets including for the current record
+        $descendants[] = $record->ID;
         $inChangeSetIDs = ChangeSetItem::get()->filter([
             'ObjectID' => $descendants,
             'ObjectClass' => SiteTree::class
@@ -26,7 +31,7 @@ class CMSMainExtension extends Extension
         }
         $numCampaigns = ChangeSet::singleton()->i18n_pluralise($affectedChangeSetCount);
         $numCampaigns = mb_strtolower($numCampaigns ?? '');
-        if ($affectedChangeSetCount > 0) {
+        if (count($descendants) > 1) {
             $message = _t(
                 __CLASS__ . '.ArchiveWarningWithChildrenAndCampaigns',
                 'Warning: This page and all of its child pages will be unpublished and automatically removed from'

--- a/tests/php/Extensions/CMSMainExtensionTest.php
+++ b/tests/php/Extensions/CMSMainExtensionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SilverStripe\CampaignAdmin\Tests\Extensions;
+
+use ReflectionMethod;
+use SilverStripe\CampaignAdmin\Extensions\CMSMainExtension;
+use SilverStripe\CMS\Controllers\CMSMain;
+use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Versioned\ChangeSet;
+
+class CMSMainExtensionTest extends SapphireTest
+{
+    protected static $required_extensions = [
+        CMSMain::class => [CMSMainExtension::class],
+    ];
+
+    public function testGetArchiveWarningMessage(): void
+    {
+        $controller = new CMSMain();
+        $reflectionMethod = new ReflectionMethod($controller, 'getArchiveWarningMessage');
+        $reflectionMethod->setAccessible(true);
+        $page = new SiteTree(['Title' => 'my page']);
+        $page->write();
+
+        // Not in a campaign
+        $this->assertStringNotContainsString(
+            'changeset',
+            $reflectionMethod->invoke($controller, $page)
+        );
+
+        $changeset = new ChangeSet();
+        $changeset->write();
+        $changeset->addObject($page);
+        $this->assertSame(
+            'Warning: This page will be unpublished and automatically removed from their associated a changeset before being sent to the archive.\n\nAre you sure you want to proceed?',
+            $reflectionMethod->invoke($controller, $page)
+        );
+
+        $childPage = new SiteTree(['ParentID' => $page->ID]);
+        $childPage->write();
+
+        $this->assertSame(
+            'Warning: This page and all of its child pages will be unpublished and automatically removed from their associated a changeset before being sent to the archive.\n\nAre you sure you want to proceed?',
+            $reflectionMethod->invoke($controller, $page)
+        );
+    }
+}


### PR DESCRIPTION
CMSMain doesn't include the record in the descendants array anymore, but we do need to know if the current record has a campaign associated with it or not.

Reflects a change in https://github.com/silverstripe/silverstripe-cms/pull/3104

> [!IMPORTANT]
> Tests for this will fail without updating the dependency constraint to the patch for the above, or it will fail on prefer-lowest CI builds. 
> I'd like to add a test for this - but I can't do that reliably until the above PR is merged and tagged.

## Issue

- https://github.com/silverstripe/silverstripe-cms/issues/3103