### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/php/CampaignAdminTest.php
+++ b/tests/php/CampaignAdminTest.php
@@ -54,7 +54,6 @@ class CampaignAdminTest extends FunctionalTest
     {
         $class = new ReflectionClass(get_class($object));
         $methodObj = $class->getMethod($method);
-        $methodObj->setAccessible(true);
         return $methodObj->invokeArgs($object, $args);
     }
 

--- a/tests/php/Extensions/CMSMainExtensionTest.php
+++ b/tests/php/Extensions/CMSMainExtensionTest.php
@@ -19,7 +19,6 @@ class CMSMainExtensionTest extends SapphireTest
     {
         $controller = new CMSMain();
         $reflectionMethod = new ReflectionMethod($controller, 'getArchiveWarningMessage');
-        $reflectionMethod->setAccessible(true);
         $page = new SiteTree(['Title' => 'my page']);
         $page->write();
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.
